### PR TITLE
Allow overriding the date format

### DIFF
--- a/src/Monolog/Formatter/LogfmtFormatter.php
+++ b/src/Monolog/Formatter/LogfmtFormatter.php
@@ -42,7 +42,8 @@ class LogfmtFormatter extends NormalizerFormatter
         $dateTimeKey = 'ts',
         $levelKey = 'lvl',
         $channelKey = 'chan',
-        $messageKey = 'msg'
+        $messageKey = 'msg',
+        $dateFormat = \DateTime::RFC3339
     ) {
         $this->timeKey = trim($dateTimeKey);
         $this->lvlKey = trim($levelKey);
@@ -52,7 +53,7 @@ class LogfmtFormatter extends NormalizerFormatter
         $this->lvlKeyValid = $this->isValidIdent($this->lvlKey);
         $this->chanKeyValid = $this->isValidIdent($this->chanKey);
         $this->msgKeyValid = $this->isValidIdent($this->msgKey);
-        $this->dateFormat = \DateTime::RFC3339;
+        $this->dateFormat = $dateFormat;
     }
     
     /**


### PR DESCRIPTION
`LogfmtFormatter` extends `NormalizerFormatter`, which will format any `DateTime` objects it finds, and allows specifying the format.

However, the `$dateFormat` field is protected, it can only be specified in the constructor, and `LogfmtFormatter` is hard-coding it.

This change keeps the same default but allows overriding the format, which is useful for adding milliseconds / microseconds to the timestamp, to preserve log line ordering.