### PR TITLE
Fix non-utf8 strings are always considered not needing quoting

### DIFF
--- a/src/Monolog/Formatter/LogfmtFormatter.php
+++ b/src/Monolog/Formatter/LogfmtFormatter.php
@@ -134,7 +134,7 @@ class LogfmtFormatter extends NormalizerFormatter
     {
         if (is_string($val)) {
             // Control chars, DEL, ", =, space
-            if (preg_match('/[\x00-\x1F\x7F\"\=\s]/u', $val)) {
+            if (preg_match('/[\x00-\x1F\x7F\"\=\s]/', $val)) {
                 return false;
             }
 


### PR DESCRIPTION
Hi Peter, thanks for this library.
I encountered an issue, using preg_match with u modifier [always returns 0](https://www.php.net/manual/en/reference.pcre.pattern.modifiers.php#:~:text=PCRE_UTF8) when searching through a non-UTF8 string, causing such strings always considered safe to output without quoting. The search in question is only matching ascii characters so it is safe to remove the modifier to make it work for any encoding, as syslog does not impose any.