### PR TITLE
Add lineSuffix to allow overriding newlines on formatted output

### DIFF
--- a/src/Monolog/Formatter/LogfmtFormatter.php
+++ b/src/Monolog/Formatter/LogfmtFormatter.php
@@ -23,6 +23,7 @@ class LogfmtFormatter extends NormalizerFormatter
     protected ?string $lvlKey;
     protected ?string $chanKey;
     protected ?string $msgKey;
+    protected ?string $lineSuffix = "\n";
 
     protected bool $timeKeyValid = true;
     protected bool $lvlKeyValid = true;
@@ -44,13 +45,15 @@ class LogfmtFormatter extends NormalizerFormatter
      * @param string|null $channelKey Key to use for the log channel name.
      * @param string|null $messageKey Key to use for the log message.
      * @param string|null $dateFormat The format of the timestamp: should be a format supported by DateTime::format
+     * @param string|null $lineSuffix The suffix to append at the end of the formatted line, defaults to a newline. (useful to set to null for syslog)
      */
     public function __construct(
         ?string $dateTimeKey = 'ts',
         ?string $levelKey = 'lvl',
         ?string $channelKey = 'chan',
         ?string $messageKey = 'msg',
-        ?string $dateFormat = DateTime::RFC3339
+        ?string $dateFormat = DateTime::RFC3339,
+        ?string $lineSuffix = "\n"
     ) {
         $this->timeKey = $dateTimeKey ? trim($dateTimeKey) : null;
         $this->lvlKey = $levelKey ? trim($levelKey) : null;
@@ -60,6 +63,7 @@ class LogfmtFormatter extends NormalizerFormatter
         $this->lvlKeyValid = $this->isValidIdent($this->lvlKey);
         $this->chanKeyValid = $this->isValidIdent($this->chanKey);
         $this->msgKeyValid = $this->isValidIdent($this->msgKey);
+        $this->lineSuffix   = $lineSuffix;
 
         parent::__construct($dateFormat);
     }
@@ -105,7 +109,7 @@ class LogfmtFormatter extends NormalizerFormatter
             $pairs[$extraKey] = $extraKey.'='.$this->stringifyVal($extraVal);
         }
 
-        return implode(' ', $pairs)."\n";
+        return implode(' ', $pairs) . $this->lineSuffix;
     }
 
     /**

--- a/src/Monolog/Formatter/LogfmtFormatter.php
+++ b/src/Monolog/Formatter/LogfmtFormatter.php
@@ -23,7 +23,7 @@ class LogfmtFormatter extends NormalizerFormatter
     protected ?string $lvlKey;
     protected ?string $chanKey;
     protected ?string $msgKey;
-    protected ?string $lineSuffix = "\n";
+    protected ?string $formattedRecordTerminator = "\n";
 
     protected bool $timeKeyValid = true;
     protected bool $lvlKeyValid = true;
@@ -45,7 +45,7 @@ class LogfmtFormatter extends NormalizerFormatter
      * @param string|null $channelKey Key to use for the log channel name.
      * @param string|null $messageKey Key to use for the log message.
      * @param string|null $dateFormat The format of the timestamp: should be a format supported by DateTime::format
-     * @param string|null $lineSuffix The suffix to append at the end of the formatted line, defaults to a newline. (useful to set to null for syslog)
+     * @param string|null $formattedRecordTerminator The suffix to append at the end of the formatted line, defaults to a newline. (useful to set to null for syslog)
      */
     public function __construct(
         ?string $dateTimeKey = 'ts',
@@ -53,7 +53,7 @@ class LogfmtFormatter extends NormalizerFormatter
         ?string $channelKey = 'chan',
         ?string $messageKey = 'msg',
         ?string $dateFormat = DateTime::RFC3339,
-        ?string $lineSuffix = "\n"
+        ?string $formattedRecordTerminator = "\n"
     ) {
         $this->timeKey = $dateTimeKey ? trim($dateTimeKey) : null;
         $this->lvlKey = $levelKey ? trim($levelKey) : null;
@@ -63,7 +63,7 @@ class LogfmtFormatter extends NormalizerFormatter
         $this->lvlKeyValid = $this->isValidIdent($this->lvlKey);
         $this->chanKeyValid = $this->isValidIdent($this->chanKey);
         $this->msgKeyValid = $this->isValidIdent($this->msgKey);
-        $this->lineSuffix   = $lineSuffix;
+        $this->formattedRecordTerminator = $formattedRecordTerminator;
 
         parent::__construct($dateFormat);
     }
@@ -109,7 +109,7 @@ class LogfmtFormatter extends NormalizerFormatter
             $pairs[$extraKey] = $extraKey.'='.$this->stringifyVal($extraVal);
         }
 
-        return implode(' ', $pairs) . $this->lineSuffix;
+        return implode(' ', $pairs) . $this->formattedRecordTerminator;
     }
 
     /**

--- a/tests/Monolog/Formatter/LogfmtFormatterTest.php
+++ b/tests/Monolog/Formatter/LogfmtFormatterTest.php
@@ -247,6 +247,14 @@ EOS;
         $this->assertEquals($expected, $formatter->formatBatch($batch));
     }
 
+    public function testOverrideLineSuffix(): void
+    {
+        $formatter = new LogfmtFormatter('ts', 'lvl', 'chan', 'msg', DateTime::RFC3339, null);
+        $record = $this->getRecord('Message');
+        $expected = 'ts=2017-11-19T19:00:00+00:00 lvl=INFO chan=app msg=Message';
+        $this->assertEquals($expected, $formatter->format($record));
+    }
+
     protected function getRecord($message = 'A log message'): array
     {
         return [


### PR DESCRIPTION
This is useful for cases where the added newline adds an extra log line in handlers like syslog.